### PR TITLE
Fix ternary code-gen to be lazy, corrects issues with file module

### DIFF
--- a/playbooks/bench/problem1.yml
+++ b/playbooks/bench/problem1.yml
@@ -1,0 +1,7 @@
+---
+- name: Create directory /srv/www
+  tasks:
+  - name: Create directory
+    ansible.builtin.file:
+      path: /srv/www
+      state: directory


### PR DESCRIPTION
Code-gen ternary so that the expressions in the branches are pushed into the conditional/exists/match in the generated code to ensure we don't improperly evaluate functions/etc.

This fixes an issue in the file module and enables the first benchmark in our suite to be interpreted properly.