### PR TITLE
Add git module

### DIFF
--- a/lib/modules/ast.ml
+++ b/lib/modules/ast.ml
@@ -21,8 +21,8 @@ type expr = Id of string | BoolLit of bool  | IntLit of int | FloatLit of float
           | CondProvidedExp of string * expr * expr
           | CondExistsExp of expr * expr * expr
 
-(* Patterns are just of the form <enum-name>::<constructor-name>[(<var-names>)] *)
-type pattern = string * string * string list
+(* Patterns are just of the form <enum-name>[::<type>]::<constructor-name>[(<var-names>)] *)
+type pattern = string * typ option * string * string list
 
 (* For VarDecls, the bool indicates whether the variables are required or not *)
 type stmt = VarDecls     of bool * (string * string list * typ * expr option) list

--- a/lib/modules/parser.ml
+++ b/lib/modules/parser.ml
@@ -319,19 +319,23 @@ let mod_arg =
 let mod_args =
   sep_by (whitespace *> char '|' *> whitespace) mod_arg
 
-(* A (match) pattern has form <enum-name>::<case-name>[(<var-names>)] *)
+(* A (match) pattern has form <enum-name>[::<type>]::<case-name>[(<var-names>)] *)
 let pattern =
   identifier
   >>= fun enum ->
   whitespace
   *> string "::"
   *> whitespace
-  *> identifier
+  *> (option None
+    (char '<' *> whitespace *> typ <* whitespace <* char '>'
+      <* whitespace <* string "::" >>| fun t -> Some t))
+  >>= fun type_arg ->
+  identifier
   >>= fun nm ->
   option []
     (whitespace
       *> parens (sep_by (whitespace *> char ',' *> whitespace) identifier))
-  >>| fun vars -> (enum, nm, vars)
+  >>| fun vars -> (enum, type_arg, nm, vars)
 
 type condType = Provided of string | Exists of expr | Condition of expr
 

--- a/modules/git.type
+++ b/modules/git.type
@@ -1,0 +1,30 @@
+struct git_result { failed: bool }
+
+uninterpreted git_files(string, string, string) -> list path
+uninterpreted git_content(string, string, string, path) -> string
+
+module ansible.builtin.git -> git_result {
+  (dest: path)
+  (repo: string)
+  (remote: string = "origin")
+  (version: string = "HEAD")
+
+  if exists fs(dest, file_system::remote) {
+    match fs(dest, file_system::remote).fs_type {
+      file_type::directory(files) => {
+        match files {
+          list::<path>::nil => {
+            let files = git_files(repo, version, remote);
+            fs(dest, file_system::remote).fs_type = file_type::directory(files);
+            for p in files {
+              fs(p, file_system::remote).fs_type = file_type::file(git_content(repo, version, remote, p));
+            }
+            return git_result { failed: false };
+          }
+        }
+      }
+    }
+  }
+
+  return git_result { failed: true };
+}


### PR DESCRIPTION
Adds the `ansible.builtin.git` module and fixes the module language to support cases over list and option types by inserting the element type, as in
```
match lst {
    list::<path>::nil => { ... }
    list::<path>::cons(hd, tl) => { ... }
}
```