### PR TITLE
Handle loops and conditions in Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,3 @@ Modules.Target.TargetInterp.interpret prg (Primitive Unit);;
 
 # TODO List
 - Add builtin variables to Ansible
-- Handle dot expressions in Ansible

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Modules.Target.TargetInterp.interpret prg (Primitive Unit);;
 ```
 
 # TODO List
+- Add builtin variables to Ansible
+- Handle dot expressions in Ansible

--- a/README.md
+++ b/README.md
@@ -7,4 +7,3 @@ Modules.Target.TargetInterp.interpret prg (Primitive Unit);;
 ```
 
 # TODO List
-- Add builtin variables to Ansible

--- a/lib/ansible/parser.ml
+++ b/lib/ansible/parser.ml
@@ -407,8 +407,16 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
             in Ok (Modules.Ast.Id nm, t)
         | Some (Unknown _), None -> Error ("Variable of unknown type used in unknown type setting, cannot solve")
         | None, _ ->
-            (* TODO: Builtin variables *)
-            Error ("Unknown variable " ^ nm)
+            (* See if this is a built-in variable *)
+            match nm with
+            | "ansible_os_family" ->
+                begin match t with
+                | Some String | None ->
+                    (* env().os_family *)
+                    Ok (Field (FuncExp (Id "env", []), "os_family"), String)
+                | _ -> Error "mismatched types"
+                end
+            | _ -> Error ("Unknown variable " ^ nm)
         end
     | Unary (v, op) ->
         begin match op, t with

--- a/lib/ansible/parser.ml
+++ b/lib/ansible/parser.ml
@@ -44,10 +44,16 @@ class mod_result name =
       else Ok { mod_name = name; args = List.of_seq (Hashtbl.to_seq args) }
   end
 
+type loop_kind =
+  | ItemLoop of value
+  | FileGlob of value
+
 type task = {
   name: string;
   register: string;
   ignore_errors: bool;
+  condition: value option;
+  loop: loop_kind option;
   module_invoke: mod_use
 }
 
@@ -56,6 +62,8 @@ class task_result =
     val mutable name          = (None : string option)
     val mutable register      = (None : string option)
     val mutable ignore_errors = (None : bool option)
+    val mutable condition     = (None : value option)
+    val mutable loop          = (None : loop_kind option)
     val mutable module_invoke = (None : mod_use option)
 
     val mutable errors        = ([] : string list)
@@ -72,6 +80,14 @@ class task_result =
       match ignore_errors with
       | None -> ignore_errors <- Some v
       | _    -> errors <- "Multiple ignore_errors fields" :: errors
+    method add_when v =
+      match condition with
+      | None -> condition <- Some v
+      | _    -> errors <- "Multiple when fields" :: errors
+    method add_loop l =
+      match loop with
+      | None -> loop <- Some l
+      | _    -> errors <- "Multiple looping fields" :: errors
     method add_module m =
       match module_invoke with
       | None   -> module_invoke <- Some m
@@ -89,6 +105,8 @@ class task_result =
             Ok { name          = Option.value name ~default:""
                ; register      = Option.value register ~default:"_"
                ; ignore_errors = Option.value ignore_errors ~default:false
+               ; condition     = condition
+               ; loop          = loop
                ; module_invoke = m }
   end
 
@@ -188,6 +206,17 @@ let rec jinja_to_value (j: Jtypes.ast) : (value, string) result =
       (fun hd -> Result.bind (jinja_to_value js)
         (fun tl -> Ok (Binary (hd, Concat, tl))))
 
+type var_typ = Unknown of string (* name of the variable *)
+             | Concrete of Modules.Ast.typ
+type play_env = (string, var_typ) Hashtbl.t
+
+let list_to_and (v: value) : value =
+  match v with
+  | List [] -> Bool true
+  | List [v] -> v
+  | List (v::vs) -> List.fold_right (fun x y -> Binary (x, And, y)) vs v
+  | _ -> v
+
 let process_ansible (file: string) (tys : Modules.Codegen.type_env)
   (env : Modules.Codegen.global_env) : (Modules.Ast.stmt list, string) result =
   let process_string v =
@@ -217,45 +246,77 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
                 (fun h -> Result.map (fun tl -> h :: tl) (process tl))
         in Result.map (fun vs -> List vs) (process vs)
     | `O _      -> Error "expected value found mapping"
-  in let rec codegen_value v (t : Modules.Ast.typ) =
+  in let rec codegen_value v (t : Modules.Ast.typ option) (play_env: play_env)
+    : (Modules.Ast.expr * Modules.Ast.typ, string) result =
     match v with
     | Int i ->
         begin match t with
-        | Int -> Ok (Modules.Ast.IntLit i)
-        | Float -> Ok (Modules.Ast.FloatLit (float_of_int i))
+        | None -> Ok (Modules.Ast.IntLit i, Modules.Ast.Int)
+        | Some Int -> Ok (Modules.Ast.IntLit i, Modules.Ast.Int)
+        | Some Float -> Ok (Modules.Ast.FloatLit (float_of_int i), Modules.Ast.Float)
+        | Some String -> Ok (Modules.Ast.StringLit (string_of_int i), Modules.Ast.String)
         | _ -> Error "Incorrect type, found integer"
         end
     | Float f ->
         begin match t with
-        | Int ->
+        | None -> Ok (Modules.Ast.FloatLit f, Modules.Ast.Float)
+        | Some Int ->
             if Float.is_integer f
-            then Ok (Modules.Ast.IntLit (Float.to_int f))
+            then Ok (Modules.Ast.IntLit (Float.to_int f), Modules.Ast.Int)
             else Error (Printf.sprintf "Expected integer found float '%f'" f)
-        | Float -> Ok (Modules.Ast.FloatLit f)
+        | Some Float -> Ok (Modules.Ast.FloatLit f, Modules.Ast.Float)
+        | Some String -> Ok (Modules.Ast.StringLit (string_of_float f), Modules.Ast.String)
         | _ -> Error ("Incorrect type, found number")
         end
     | Bool b ->
         begin match t with
-        | Bool -> Ok (Modules.Ast.BoolLit b)
+        | None -> Ok (Modules.Ast.BoolLit b, Modules.Ast.Bool)
+        | Some Bool -> Ok (Modules.Ast.BoolLit b, Modules.Ast.Bool)
+        | Some String -> Ok (Modules.Ast.StringLit (string_of_bool b), Modules.Ast.String)
         | _ -> Error ("Incorrect type, found bool")
         end
     | List vs ->
+        (* We construct a list as a series of cons *)
         begin match t with
-        | List el ->
-            (* We construct a list as a series of cons *)
+        | None ->
+            let vals =
+              List.fold_right
+                (fun v tl_info ->
+                  Result.bind tl_info
+                    (fun (tl, el) ->
+                      Result.map (fun (v, t) -> (v :: tl, Some t))
+                        (codegen_value v el play_env)))
+                vs
+                (Ok ([], None))
+            in Result.bind vals
+              (fun (vals, elem_typ) ->
+                match elem_typ with
+                | None -> Error "could not determine the type of a list"
+                | Some el ->
+                    Ok (List.fold_right
+                      (fun v e ->
+                        Modules.Ast.EnumExp (
+                          Id "list",
+                          Some el,
+                          "cons",
+                          [v; e]))
+                      vals
+                      (Modules.Ast.EnumExp (Id "list", Some el, "nil", [])),
+                      Modules.Ast.List el))
+        | Some (List el) ->
             let vals =
               let rec process_vals vs =
                 match vs with
                 | [] -> Ok []
                 | v :: vs ->
-                    match codegen_value v el with
-                    | Ok v ->
+                    match codegen_value v (Some el) play_env with
+                    | Ok (v, _) ->
                         Result.map (fun tl -> v :: tl) (process_vals vs)
                     | Error msg -> Error msg
               in process_vals vs
             in Result.map
                 (fun vals ->
-                  List.fold_right
+                  (List.fold_right
                     (fun v e -> 
                       Modules.Ast.EnumExp (
                         Id "list",
@@ -264,7 +325,8 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
                         [v; e]))
                     vals
                     (* Nil list *)
-                    (Modules.Ast.EnumExp (Id "list", Some el, "nil", [])))
+                    (Modules.Ast.EnumExp (Id "list", Some el, "nil", [])),
+                    Modules.Ast.List el))
                 vals
         | _ -> Error ("Incorrect type, found list")
         end
@@ -272,18 +334,19 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
         (* Strings in YAML can actually represent many things in our type-system,
          * specifically strings, paths, and enum values *)
         begin match t with
-        | String -> Ok (StringLit s)
-        | Path   -> Ok (PathLit s)
-        | Named nm ->
+        | None -> Ok (StringLit s, Modules.Ast.String)
+        | Some String -> Ok (StringLit s, Modules.Ast.String)
+        | Some Path   -> Ok (PathLit s, Modules.Ast.Path)
+        | Some (Named nm) ->
             begin match Modules.Codegen.UniqueMap.find nm tys with
             | None -> Error ("Internal Error: type of module argument undefined")
-            | Some t ->
-                let rec process_for_type (t : Modules.Codegen.typ)
-                  : (Modules.Ast.expr, string) result =
-                  match t with
-                  | String -> Ok (StringLit s)
-                  | Path   -> Ok (PathLit s)
-                  | Placeholder { contents = Some t } -> process_for_type t
+            | Some typ ->
+                let rec process_for_type (typ : Modules.Codegen.typ)
+                  : (Modules.Ast.expr * Modules.Ast.typ, string) result =
+                  match typ with
+                  | String -> Ok (StringLit s, Named nm)
+                  | Path   -> Ok (PathLit s, Named nm)
+                  | Placeholder { contents = Some typ } -> process_for_type typ
                   | Placeholder { contents = None } -> Error ("Internal Error: unknown placeholder")
                   | Enum (_, constructors) ->
                       begin match Modules.Codegen.StringMap.find_opt s constructors with
@@ -293,40 +356,56 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
                           (String.concat ", " 
                             (List.map fst 
                               (Modules.Codegen.StringMap.bindings constructors))))
-                      | Some (_, []) -> Ok(EnumExp (Id nm, None, s, []))
+                      | Some (_, []) -> Ok(EnumExp (Id nm, None, s, []), Named nm)
                       | Some (_, _) -> Error (Printf.sprintf
                           "Constructor %s cannot be used from Ansible, has argument"
                           s)
                       end
                   | _ -> Error ("Incorrect type, found string-like")
-                in process_for_type t
+                in process_for_type typ
             end
         | _ -> Error ("Incorrect type, found string-like")
         end
-    | Ident nm -> Ok (Modules.Ast.Id nm)
+    | Ident nm ->
+        begin match Hashtbl.find_opt play_env nm, t with
+        | Some (Concrete ty), Some t when t = ty -> Ok (Modules.Ast.Id nm, t)
+        | Some (Concrete _), Some _ -> Error "mismatched types"
+        | Some (Concrete ty), None -> Ok (Modules.Ast.Id nm, ty)
+        | Some (Unknown _), Some t ->
+            let () = Hashtbl.add play_env nm (Concrete t)
+            in Ok (Modules.Ast.Id nm, t)
+        | Some (Unknown _), None -> Error ("Variable of unknown type used in unknown type setting, cannot solve")
+        | None, _ -> Error ("Unknown variable " ^ nm)
+        end
     | Unary (v, op) ->
         begin match op, t with
-        | Not, Bool -> 
-            Result.map (fun v -> Modules.Ast.UnaryExp (v, Not)) (codegen_value v Bool)
+        | Not, Some Bool | Not, None -> 
+            Result.bind (codegen_value v (Some Bool) play_env)
+              (fun (v, t) -> Ok (Modules.Ast.UnaryExp (v, Not), t))
         | Not, _ -> Error "Incorrect type for not (productes boolean)"
         end
     | Binary (lhs, op, rhs) ->
-        let op_info : (Modules.Ast.typ * Modules.Ast.typ * Modules.Ast.binary, string) result =
+        let op_info : (Modules.Ast.typ option 
+                    * (Modules.Ast.typ -> Modules.Ast.typ option)
+                    * Modules.Ast.typ
+                    * Modules.Ast.binary, string) result =
           match op, t with
-          | Concat, String -> Ok (String, String, Concat)
+          | Concat, Some String | Concat, None
+              -> Ok (Some String, (fun _ -> Some String), String, Concat)
           | Concat, _ -> Error "Incorrect type for concat (produces string)"
-          (* FIXME: This probably isn't the correct type for equality... *)
-          | Equals, Bool -> Ok (String, String, Eq)
+          | Equals, Some Bool | Equals, None
+              -> Ok (None, (fun t -> Some t), Bool, Eq)
           | Equals, _ -> Error "Incorrect type for equals (produces bool)"
-          | And, Bool -> Ok (Bool, Bool, And)
+          | And, Some Bool | And, None -> Ok (Some Bool, (fun _ -> Some Bool), Bool, And)
           | And, _ -> Error "Incorrect type for and (produces bool)"
-          | Or, Bool -> Ok (Bool, Bool, Or)
+          | Or, Some Bool | Or, None -> Ok (Some Bool, (fun _ -> Some Bool), Bool, Or)
           | Or, _ -> Error "Incorrect type for or (produces bool)"
         in Result.bind op_info
-          (fun (lhs_t, rhs_t, op) ->
-            Result.bind (codegen_value lhs lhs_t)
-              (fun lhs -> Result.bind (codegen_value rhs rhs_t)
-                (fun rhs -> Ok (Modules.Ast.BinaryExp (lhs, rhs, op)))))
+          (fun (lhs_t, rhs_t, ret_typ, op) ->
+            Result.bind (codegen_value lhs lhs_t play_env)
+              (fun (lhs, lhs_t) ->
+                Result.bind (codegen_value rhs (rhs_t lhs_t) play_env)
+                (fun (rhs, _) -> Ok (Modules.Ast.BinaryExp (lhs, rhs, op), ret_typ))))
     | Dot (_, _) -> Error "TODO: Implement dot operator"
   in let process_module_use nm args =
     match args with
@@ -352,6 +431,11 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
                 | "name" -> Result.map res#add_name (process_string v)
                 | "register" -> Result.map res#add_register (process_string v)
                 | "ignore_errors" -> Result.map res#add_ignore_errors (process_bool v)
+                | "when" -> Result.map res#add_when (process_value v)
+                | "with_items" | "loop"
+                  -> Result.map (fun v -> res#add_loop (ItemLoop v)) (process_value v)
+                | "with_fileglob"
+                  -> Result.map (fun v -> res#add_loop (FileGlob v)) (process_value v)
                 | _ -> Result.map res#add_module (process_module_use field v)
               with
               | Ok () -> process_task_fields tl res
@@ -372,7 +456,7 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
               | Error mhd, Error mtl -> Error (mhd ^ "\n" ^ mtl)
         in process seq
     | _      -> Error "expected sequence of tasks"
-  in let codegen_module_invocation m =
+  in let codegen_module_invocation m (play_env: play_env) =
     let module_name = String.split_on_char '.' m.mod_name
     in let module_expr =
       match module_name with
@@ -386,6 +470,7 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
     | Some mod_info ->
         let arg_aliases = mod_info.alias_map
         in let arg_types = mod_info.args
+        in let res_type = mod_info.ret_type
         in let module_args =
           let rec process_args args =
             match args with
@@ -398,31 +483,64 @@ let process_ansible (file: string) (tys : Modules.Codegen.type_env)
                 in match Modules.Codegen.StringMap.find_opt canon_name arg_types with
                 | None -> Error (Printf.sprintf "No argument %s of module %s" nm m.mod_name)
                 | Some t ->
-                    match codegen_value v t with
-                    | Ok e -> Result.map (fun tl -> (canon_name, e) :: tl) (process_args tl)
+                    match codegen_value v (Some t) play_env with
+                    | Ok (e, _) -> Result.map (fun tl -> (canon_name, e) :: tl) (process_args tl)
                     | Error msg -> Error msg
           in process_args m.args
-        in Result.map (fun args -> Modules.Ast.ModuleExp (module_expr, args))
-            module_args
-  in let codegen_task (t : task) : (Modules.Ast.stmt list, string) result =
-    Result.map
-      (fun v ->
-        Modules.Ast.LetStmt (t.register, v)
-        ::
-        if t.ignore_errors
-        then []
-        else Assert (UnaryExp (Field (Id t.register, "failed"), Not)) :: [])
-      (codegen_module_invocation t.module_invoke)
+        in Result.map 
+          (fun args -> (Modules.Ast.ModuleExp (module_expr, args), res_type))
+          module_args
+  in let codegen_task (t : task) (play_env: play_env)
+    : (Modules.Ast.stmt list, string) result =
+    let () = if Option.is_some t.loop then Hashtbl.add play_env "item" (Unknown "item")
+    in Result.bind (codegen_module_invocation t.module_invoke play_env)
+      (fun (modul, typ) ->
+        let body = Modules.Ast.LetStmt (t.register, modul)
+                :: if t.ignore_errors then []
+                   else [Assert (UnaryExp (Field (Id t.register, "failed"), Not))]
+        in let conditioned =
+          match t.condition with
+          | None -> Ok body
+          | Some cond ->
+              Result.bind
+                (codegen_value (list_to_and cond) (Some Bool) play_env)
+                (fun (c, _) -> Ok [Modules.Ast.IfThenElse (c, body, [])])
+        in let () = 
+          if t.register <> "_" then Hashtbl.add play_env t.register (Concrete typ)
+        in let looped =
+          match t.loop with
+          | None -> conditioned
+          | Some (ItemLoop lst) ->
+              let item_typ = match Hashtbl.find play_env "item" with
+                             (* If there's no known type for the items, just
+                                treat them as strings *)
+                             | Unknown _ -> Modules.Ast.String
+                             | Concrete t -> t
+              in Result.bind (codegen_value lst (Some (List item_typ)) play_env)
+              (fun (lst, _) ->
+                Result.bind conditioned
+                  (fun conditioned ->
+                    Ok [Modules.Ast.ForLoop ("item", lst, conditioned)]))
+          | Some (FileGlob glob) ->
+              Result.bind (codegen_value glob (Some String) play_env)
+                (fun (glob, _) ->
+                  let files = Modules.Ast.FuncExp (Id "file_glob", [glob])
+                  in Result.bind conditioned
+                    (fun conditioned ->
+                      Ok [Modules.Ast.ForLoop ("item", files, conditioned)]))
+        in let () = if Option.is_some t.loop then Hashtbl.remove play_env "item"
+        in looped)
   in let codegen_play (play : play) : (Modules.Ast.stmt list, string) result =
     (* TODO: for now we're ignoring hosts. We should also handle setting is_root *)
-    let rec codegen_tasks ts =
+    let rec codegen_tasks ts play_env =
       match ts with
       | [] -> Ok []
       | t :: tl ->
-          match codegen_task t with
-          | Ok t -> Result.map (fun tl -> t @ tl) (codegen_tasks tl)
+          match codegen_task t play_env with
+          | Ok t -> Result.map (fun tl -> t @ tl) (codegen_tasks tl play_env)
           | Error msg -> Error msg
-    in let tasks = codegen_tasks play.tasks
+    in let play_env = Hashtbl.create 10
+    in let tasks = codegen_tasks play.tasks play_env
     (* Set the user by env().user = remote_user *)
     in Result.map
       (fun tasks ->

--- a/lib/calculus/ast.ml
+++ b/lib/calculus/ast.ml
@@ -99,9 +99,12 @@ module type Ast_Defs = sig
   (* Used to handle conditionals
    * - isTruthType returns whether a type can be used like a truth value 
    * - asTruth takes a value and produces its truth value (true/false) or
-   *   fails if it cannot be reduced to a boolean value for any reason *)
+   *   fails if it cannot be reduced to a boolean value for any reason
+   * - boolAsVAlue takes a boolean and returns a value representing that bool
+   *)
   val isTruthType : typ -> bool
   val asTruth : value -> bool option
+  val boolAsValue : bool -> value
   
   (* Used to handle loops
    * - To determine that a type is loop-like we need to know if types are unit
@@ -114,4 +117,17 @@ module type Ast_Defs = sig
   val envType : typ
   val envToVal : env -> value
   val envFromVal : value -> env
+
+  (* Many times constraints on function values can be simplified in some manner,
+   * for instance (not v) = true is equivalent to v = false which is simpler
+   * or (and x y) = true is equivalent to x = y = true. To enable such
+   * simplifications we allow implementations to define how constraints on a
+   * function can be simplified *)
+  type constr = IsBool of bool | IsConstructor of bool * (id * typ)
+  type result_constraint = IsBool        of value * bool
+                         | IsConstructor of value * (bool * (id * typ))
+                         | IsEqual       of id * value
+  type func_constraints = Unreducible | Reducible of result_constraint list list
+
+  val reduceFuncConstraint : funct -> value -> constr -> func_constraints
 end

--- a/lib/calculus/interp.ml
+++ b/lib/calculus/interp.ml
@@ -212,6 +212,8 @@ module Interp(Ast : Ast.Ast_Defs) = struct
             in match asTruth new_v with
             | Some c -> if b = c then Some new_bools else None
             | None ->
+                (* TODO: the substitution (and simplification) might enable us
+                 * to simplify the constraint *)
                 match ValueMap.find_opt new_v new_bools with
                 | None -> Some (ValueMap.add new_v b new_bools)
                 | Some c -> if b = c then Some new_bools else None))

--- a/lib/calculus/interp.ml
+++ b/lib/calculus/interp.ml
@@ -1,6 +1,8 @@
 let uid = Ast.uid
 type uid = Ast.uid
 
+type id = Ast.id
+
 module Interp(Ast : Ast.Ast_Defs) = struct
   open Ast
 
@@ -10,7 +12,7 @@ module Interp(Ast : Ast.Ast_Defs) = struct
   end
   module ValueMap : Map.S with type key = value = Map.Make(ValueOrder)
 
-  (* States are made up of maps of qualifiers. For elements, we store the 
+  (* States are made up of maps of qualifiers. For elements, we store the
    * element, value, and whether or not it is negated (true = negated) as the
    * key and the value is qualifiers applied to it. For attributes, the key is
    * just the attribute and whether it is negated and this maps to the value and
@@ -65,9 +67,11 @@ module Interp(Ast : Ast.Ast_Defs) = struct
           | [] -> state
     in helper (ElementMap.bindings els) (AttributeMap.bindings ats) ps
 
-  type prg_type = { 
+  type loop_info = AllUnknown of uid | AllKnown of value | LastKnown of uid * value
+
+  type prg_type = {
     init : state; final : state;
-    loops : uid ValueMap.t;  (* Map between values and the loop variable over that value *)
+    loops : loop_info ValueMap.t; (* Map between values and the loop variable over that value *)
     bools : bool ValueMap.t; (* Map between values and its boolean value *)
     constrs : (bool * value) ValueMap.t; (* Map between values and its constructor value (true = L) *)
   }
@@ -112,7 +116,7 @@ module Interp(Ast : Ast.Ast_Defs) = struct
           then st
           else helper_state st)
         els
-    and helper_ats (ats : (value * state) AttributeMap.t) = 
+    and helper_ats (ats : (value * state) AttributeMap.t) =
       AttributeMap.map (fun (v, st) -> (v, helper_state st)) ats
     and helper_state (State (els, ats) : state) : state =
       State (helper_els els, helper_ats ats)
@@ -154,6 +158,185 @@ module Interp(Ast : Ast.Ast_Defs) = struct
     | Pair (_, _, t) -> t
     | Constructor (n, _, _) -> Named n
     | Struct (s, _) -> Struct s
+
+  let substitute_unknown (u: id) (v: value) (s: prg_type) (env: env)
+    : (prg_type * env) option =
+    (* Substitution here also tries to evaluate expressions further, by seeing
+     * whether functions can now reduce *)
+    let rec subst_in_value (w: value) : value =
+      match w with
+      | Unknown (w, _) when u = w -> v
+      | Unknown (_, _) | Literal (_, _) -> w
+      | Function (f, v, t) ->
+          let new_v = subst_in_value v
+          in let (_, _, f_def) = funcDef f
+          in begin match f_def new_v with
+          | Reduced w -> w
+          | Stuck -> Function (f, new_v, t)
+          | Err msg ->
+              (* FIXME *)
+              failwith ("While substituting an unknown, a function evaluation failed: " ^ msg)
+          end
+      | Pair (x, y, t) -> Pair (subst_in_value x, subst_in_value y, t)
+      | Constructor (n, c, v) -> Constructor (n, c, subst_in_value v)
+      | Struct (t, r) -> Struct (t, FieldMap.map subst_in_value r)
+    in let rec subst_in_state (s: state) =
+      match s with
+      | State (elems, attrs) ->
+          let with_elems =
+            ElementMap.fold
+              (fun (el, v, neg) s new_state ->
+                let new_v = subst_in_value v
+                in let new_s = subst_in_state s
+                in add_qual (Either.Left (el, neg), new_v, new_s) new_state)
+              elems
+              init_state
+          in let with_attrs =
+            AttributeMap.fold
+              (fun attr (v, s) new_state ->
+                let new_v = subst_in_value v
+                in let new_s = subst_in_state s
+                in add_qual (Either.Right attr, new_v, new_s) new_state)
+              attrs
+              with_elems
+          in with_attrs
+    in let new_env = VariableMap.map (fun (v, t) -> (subst_in_value v, t)) env
+    in let new_init = subst_in_state s.init
+    in let new_final = subst_in_state s.final
+    in let new_bools =
+      ValueMap.fold
+        (fun bound b new_bools ->
+          Option.bind new_bools
+          (fun new_bools ->
+            let new_v = subst_in_value bound
+            in match asTruth new_v with
+            | Some c -> if b = c then Some new_bools else None
+            | None ->
+                match ValueMap.find_opt new_v new_bools with
+                | None -> Some (ValueMap.add new_v b new_bools)
+                | Some c -> if b = c then Some new_bools else None))
+        s.bools
+        (Some ValueMap.empty)
+    in let new_constrs =
+      (* The problem with unification is it can produce other substitutions
+       * of values that need to be performed. This actually can be implemented
+       * and would be nice, but I'm not figuring that all out right now *)
+      let unify_values _ _ : (bool * value) ValueMap.t option =
+        failwith "unification of values during substitution of an unknown is not supported"
+      in ValueMap.fold
+        (fun bound (which, arg) new_constrs ->
+          Option.bind new_constrs
+          (fun new_constrs ->
+            let new_v = subst_in_value bound
+            in let new_arg = subst_in_value arg
+            in match new_v with
+            | Constructor (_, c, w) ->
+                if which = c then unify_values new_arg w else None
+            | _ ->
+                match ValueMap.find_opt new_v new_constrs with
+                | None ->
+                    Some (ValueMap.add new_v (which, new_arg) new_constrs)
+                | Some (c, w) ->
+                    if which = c then unify_values new_arg w else None))
+        s.constrs
+        (Some ValueMap.empty)
+    in let new_loops =
+      let unify_loops _ _ : loop_info ValueMap.t option =
+        failwith "unification of loops during substitution of an unknown is not supported"
+      in ValueMap.fold
+        (fun lst loop new_loops ->
+          Option.bind new_loops
+          (fun new_loops ->
+            let new_lst = subst_in_value lst
+            in let new_loop =
+              match loop, u with
+              | AllUnknown i, Loop j when i = j -> AllKnown v
+              | AllUnknown i, Val j when i = j -> LastKnown (i, v)
+              | AllUnknown _, _ -> loop
+              | AllKnown w, _ -> AllKnown (subst_in_value w)
+              | LastKnown (i, _w), Loop j when i = j ->
+                  (* FIXME: Should unify w and v *) AllKnown v
+              | LastKnown (i, w), _ -> LastKnown (i, subst_in_value w)
+            in match ValueMap.find_opt new_lst new_loops with
+            | None -> Some (ValueMap.add new_lst new_loop new_loops)
+            | Some l -> unify_loops new_loop l))
+        s.loops
+        (Some ValueMap.empty)
+    in Option.bind new_bools (fun new_bools ->
+        Option.bind new_constrs (fun new_constrs ->
+          Option.bind new_loops (fun new_loops ->
+            Some ({ init = new_init; final = new_final;
+                    loops = new_loops; bools = new_bools;
+                    constrs = new_constrs; }, new_env))))
+
+  let rec addConstraint (v: value) (c: constr) (s: prg_type) (env: env)
+    : (prg_type * env) list =
+    let addConstraint_basic (v: value) (c : constr) (s: prg_type) (env: env) =
+      match c with
+      | IsBool b ->
+          let new_bools = ValueMap.add v b s.bools
+          in ({ init = s.init; final = s.final; loops = s.loops;
+                bools = new_bools; constrs = s.constrs; },
+              env)
+      | IsConstructor (which, (id, typ)) ->
+          let new_constrs = ValueMap.add v (which, Unknown (id, typ)) s.constrs
+          in ({ init = s.init; final = s.final; loops = s.loops;
+                bools = s.bools; constrs = new_constrs; },
+              env)
+    in let checkValue (v: value) (c: constr) (s: prg_type) (env: env) =
+      match c with
+      | IsBool b ->
+          begin match ValueMap.find_opt v s.bools with
+          | Some c when b = c -> Some [(s, env)]
+          | Some _ -> Some [] (* b <> c, no way to satisfy this constraint *)
+          | None -> None
+          end
+      | IsConstructor (which, (id, _)) ->
+          match ValueMap.find_opt v s.constrs with
+          | Some (b, v) when which = b ->
+              Option.map (fun x -> [x]) (substitute_unknown id v s env)
+          | Some (_, _) -> Some [] (* different constructors, no way to satisfy *)
+          | None -> None
+    in match checkValue v c s env with
+    | Some res -> res
+    | None ->
+    match v with
+    | Unknown (id, typ) ->
+        let new_val =
+          match c with
+          | IsBool b -> boolAsValue b
+          | IsConstructor (which, (id, id_typ)) ->
+              let ty =
+                match typ with
+                | Named nm -> nm
+                | _ -> failwith "Error: invalid type for constructor"
+              in Constructor (ty, which, Unknown (id, id_typ))
+        in Option.fold ~none:[] ~some:(fun x -> [x])
+            (substitute_unknown id new_val s env)
+    | Function (f, arg, _) ->
+        begin match reduceFuncConstraint f arg c with
+        | Reducible options ->
+            List.flatten (List.map
+              (fun cs -> List.fold_left
+                (fun states c ->
+                  match c with
+                  | IsBool (v, b) -> List.flatten (List.map
+                      (fun (s, env) -> addConstraint v (IsBool b) s env)
+                      states)
+                  | IsConstructor (v, (which, arg)) -> List.flatten (List.map
+                      (fun (s, env) ->
+                        addConstraint v (IsConstructor (which, arg)) s env)
+                      states)
+                  | IsEqual (id, v) ->
+                      List.filter_map
+                        (fun (s, env) -> substitute_unknown id v s env)
+                        states)
+                [(s, env)]
+                cs)
+              options)
+        | Unreducible -> [addConstraint_basic v c s env]
+        end
+    | _ -> [addConstraint_basic v c s env]
 
   let interpret (s : stmt) (retTy : typ) : prg_res list =
     let rec eval_expr (e : expr) (env : env) : (value * typ) error =
@@ -433,16 +616,17 @@ module Interp(Ast : Ast.Ast_Defs) = struct
           (* Identify whether there's already a "loop variable" for looping over
            * this value. If so, use it, otherwise create our own.
            * If we create our own, we also update the map in the state *)
-          let (uid, s) =
+          let (loopvar, uid, s) =
             match ValueMap.find_opt lst s.loops with
-            | Some uid -> (uid, s)
+            | Some (AllUnknown uid) | Some (LastKnown (uid, _))
+                -> (Unknown (Loop uid, elemTy), Some uid, s)
+            | Some (AllKnown v) -> (v, None, s)
             | None ->
                 let uid = uid ()
                 in let state = { init  = s.init; final = s.final;
-                                 loops = ValueMap.add lst uid s.loops;
+                                 loops = ValueMap.add lst (AllUnknown uid) s.loops;
                                  bools = s.bools; constrs = s.constrs; }
-                in (uid, state)
-          in let loopvar : value = Unknown (Loop uid, elemTy)
+                in (Unknown (Loop uid, elemTy), Some uid, state)
           in let res_loop = interp body s (VariableMap.add var (loopvar, elemTy) env) envType
           in List.flatten
               (List.map
@@ -458,8 +642,12 @@ module Interp(Ast : Ast.Ast_Defs) = struct
                    * last element of the list *)
                   | Ok (s, e) ->
                       interp next
-                        (state_replace_loopvar s uid elemTy)
-                        (env_replace_loopvar (envFromVal e) uid elemTy)
+                        (Option.fold ~none:s
+                          ~some:(fun uid -> state_replace_loopvar s uid elemTy)
+                          uid)
+                        (Option.fold ~none:env
+                          ~some:(fun uid -> env_replace_loopvar (envFromVal e) uid elemTy)
+                          uid)
                         ret)
                 res_loop)
     and interp (b : stmt) (s : prg_type) (env : env) (ret : typ) : prg_res list =
@@ -529,8 +717,8 @@ module Interp(Ast : Ast.Ast_Defs) = struct
           end
       (* For both cond and match we try to reduce the expression to a concrete
        * value that we can branch on. However, if it cannot reduce to such an
-       * expression then we check the constraints stored in the state and
-       * if there's nothing there try both possible options *)
+       * expression then we try both possible options (which involves
+       * interacting with the constraints of the current state) *)
       | Cond     (expr, thn, els) ->
           begin match eval_expr expr env with
           | Err msg -> Err msg :: []
@@ -540,24 +728,18 @@ module Interp(Ast : Ast.Ast_Defs) = struct
               else match asTruth v with
                    | Some true -> interp thn s env ret
                    | Some false -> interp els s env ret
-                   (* Since the value cannot be evaluated fully, check if we've
-                    * already evaluated it, and otherwise try both possible
-                    * values *)
+                   (* Since the value cannot be evaluated fully try both
+                    * possible values *)
                    | None ->
-                       match ValueMap.find_opt v s.bools with
-                       | Some true -> interp thn s env ret
-                       | Some false -> interp els s env ret
-                       | None ->
-                           let bools_true = ValueMap.add v true s.bools
-                           in let bools_false = ValueMap.add v false s.bools
-                           in (interp thn { init = s.init; final = s.final;
-                                            loops = s.loops; bools = bools_true;
-                                            constrs = s.constrs; }
-                                      env ret)
-                            @ (interp els { init = s.init; final = s.final;
-                                            loops = s.loops; bools = bools_false;
-                                            constrs = s.constrs; }
-                                      env ret)
+                      (List.flatten
+                        (List.map
+                          (fun (s, env) -> interp thn s env ret)
+                          (addConstraint v (IsBool true) s env)))
+                      @
+                      (List.flatten
+                        (List.map
+                          (fun (s, env) -> interp els s env ret)
+                          (addConstraint v (IsBool false) s env)))
           end
       | Match    (expr, var, left, right) ->
           begin match eval_expr expr env with
@@ -570,37 +752,29 @@ module Interp(Ast : Ast.Ast_Defs) = struct
                       let t = (if b then fst else snd) (namedTyDef n)
                       in interp (if b then left else right) s
                             (VariableMap.add var (v, t) env) ret
-                  (* The value cannot be evaluated sufficiently, so check the
-                   * constraints for it and otherwise try both options *)
+                  (* The value cannot be evaluated sufficiently, so try both
+                   * options *)
                   | _ ->
-                      match ValueMap.find_opt v s.constrs with
-                      | Some (b, v) ->
-                          let t = (if b then fst else snd) (namedTyDef n)
-                          in interp (if b then left else right) s
-                                (VariableMap.add var (v, t) env) ret
-                      | None ->
-                          let type_left = fst (namedTyDef n)
-                          in let val_left : value =
-                            Unknown (Val (uid ()), type_left)
-                          in let type_right = snd (namedTyDef n)
-                          in let val_right : value =
-                            Unknown (Val (uid ()), type_right)
-                          in let constr_left =
-                            ValueMap.add v (true, val_left) s.constrs
-                          in let constr_right =
-                            ValueMap.add v (false, val_right) s.constrs
-                          in let env_left =
-                            VariableMap.add var (val_left, type_left) env
-                          in let env_right =
-                            VariableMap.add var (val_right, type_right) env
-                          in (interp left { init = s.init; final = s.final;
-                                            loops = s.loops; bools = s.bools;
-                                            constrs = constr_left; }
-                                     env_left ret)
-                          @ (interp right { init = s.init; final = s.final;
-                                            loops = s.loops; bools = s.bools;
-                                            constrs = constr_right; }
-                                    env_right ret)
+                      let type_left = fst (namedTyDef n)
+                      in let id_left : id = Val (uid ())
+                      in let val_left = Unknown (id_left, type_left)
+                      in let type_right = snd (namedTyDef n)
+                      in let id_right : id = Val (uid ())
+                      in let val_right = Unknown (id_right, type_right)
+                      in let env_left =
+                        VariableMap.add var (val_left, type_left) env
+                      in let env_right =
+                        VariableMap.add var (val_right, type_right) env
+                      in (List.flatten
+                        (List.map
+                          (fun (s, env) -> interp left s env ret)
+                          (addConstraint v (IsConstructor (true, (id_left, type_left)))
+                            s env_left)))
+                      @ (List.flatten
+                        (List.map
+                          (fun (s, env) -> interp right s env ret)
+                          (addConstraint v (IsConstructor (false, (id_right, type_right)))
+                            s env_right)))
                   end
               | _ -> Err "Cannot match over non-named type" :: []
           end

--- a/lib/modules/codegen.ml
+++ b/lib/modules/codegen.ml
@@ -40,7 +40,8 @@ type typ = Bool | Int | Float | String | Path | Unit
          | Option      of typ
          | List        of typ
          | Product     of typ list
-         | Struct      of typ StringMap.t
+         (* Store the name of the struct along with the info on its fields *)
+         | Struct      of string * typ StringMap.t
          (* Store the name of the enum along with the info on its constructors *)
          | Enum        of string * (int * typ list) StringMap.t
          | Placeholder of typ placeholder
@@ -260,7 +261,7 @@ let rec target_type (t : typ) : Target.typ =
   | Option t -> Named (Option (target_type t))
   | List t -> Named (List (target_type t))
   | Product ts -> construct_prod ts
-  | Struct fs -> Struct (StringMap.map target_type fs)
+  | Struct (_, fs) -> Struct (StringMap.map target_type fs)
   | Enum (nm, cs) -> construct_cases nm cs
   | Placeholder t ->
       match !t with
@@ -555,7 +556,7 @@ let rec process_expr (e : Ast.expr) env tys locals (is_mod : mod_info option)
         begin match nm with
         | Id nm ->
             begin match UniqueMap.find nm tys with
-            | Some (Struct struct_def) ->
+            | Some (Struct (_, struct_def)) ->
                 let target_struct = StringMap.map target_type struct_def
                 in let init_struct : Target.expr
                   = Function (EmptyStruct target_struct, Literal (Unit ()))
@@ -1612,7 +1613,7 @@ let codegen (files : Ast.topLevel list list) : type_env * global_env =
         let fields =
           StringMap.of_list
             (List.map (fun (nm, t) -> (nm, create_type t env)) fields)
-        in add_type nm (Struct fields) env; create_types tl env
+        in add_type nm (Struct (nm, fields)) env; create_types tl env
     | Type (nm, typ) :: tl ->
         let ty = create_type typ env
         in add_type nm ty env; create_types tl env

--- a/modules/env.type
+++ b/modules/env.type
@@ -5,3 +5,4 @@ attribute user(string)
 attribute group(string)
 
 attribute hostname(string)
+attribute os_family(string)

--- a/playbooks/cond_test.yml
+++ b/playbooks/cond_test.yml
@@ -1,0 +1,10 @@
+---
+- name: Test conditions
+  remote_user: aaron
+
+  tasks:
+  - name: Delete file on Debian
+    ansible.builtin.file:
+      path: /file/debian
+      state: touch
+    when: ansible_os_family == "Debian"

--- a/playbooks/cond_test.yml
+++ b/playbooks/cond_test.yml
@@ -6,5 +6,23 @@
   - name: Delete file on Debian
     ansible.builtin.file:
       path: /file/debian
+      state: absent
+    when: ansible_os_family == "Debian"
+
+  - name: Create empty file on Debian
+    ansible.builtin.file:
+      path: /file/debian
       state: touch
     when: ansible_os_family == "Debian"
+
+  - name: Delete file on RedHat
+    ansible.builtin.file:
+      path: /file/redhat
+      state: absent
+    when: ansible_os_family == "RedHat"
+
+  - name: Create empty file on RedHat
+    ansible.builtin.file:
+      path: /file/redhat
+      state: touch
+    when: ansible_os_family == "RedHat"

--- a/playbooks/loop_test.yml
+++ b/playbooks/loop_test.yml
@@ -1,0 +1,12 @@
+---
+- name: Test loops
+  remote_user: aaron
+
+  tasks:
+  - name: Create new files
+    ansible.builtin.file:
+      path: /path/to/file
+      state: "{{ item }}"
+    with_items:
+      - absent
+      - touch


### PR DESCRIPTION
Adds support for conditionals (`when:`) and loops (`with_items:`, `loop:`, and `with_fileglob:`) in Ansible. This involves handling Jinja expressions and being able to code-gen them; which involves significant modifications to the ansible parser.

Also includes an update to the interpreters handling of constraints so that constraints on functions can be propagated to arguments, such as `not(x) = false` becoming `x = true`. The interpreter also handles substituting constrained variables, so that we avoid constraints of form `?n = ex` and just replace all uses of `?n` with `ex`.